### PR TITLE
Remove pyspice_circuit data attribute. Closes #67

### DIFF
--- a/src/common/plugins/CircuitAnalysisBases.py
+++ b/src/common/plugins/CircuitAnalysisBases.py
@@ -86,8 +86,6 @@ class CircuitToPySpiceBase(PluginBase):
         self._ground_pins = set()
         self.nodes_count = 0
         self.pin_labels = dict()
-        circuit_name = self.core.get_attribute(circuit, "name")
-        self._log_debug(f"Initialized empty PySpice circuit for {circuit_name}")
 
     def _identify_pins(self, circuit: dict) -> None:
         """Identify the pins and build adjacency list for pins

--- a/src/common/plugins/CircuitAnalysisBases.py
+++ b/src/common/plugins/CircuitAnalysisBases.py
@@ -44,6 +44,7 @@ class CircuitToPySpiceBase(PluginBase):
     def convert_to_pyspice(self, circuit: dict) -> None:
         """Convert the webgme circuit to PySpice Circuit"""
         self._assign_meta_functions()
+        pyspice_circuit = None
         if not self.is_circuit(node=circuit):
             err_msg = (
                 f"Node ({self.core.get_path(node=self.active_node)}) "
@@ -58,7 +59,10 @@ class CircuitToPySpiceBase(PluginBase):
             self._identify_pins(circuit)
             self._expand_junction_adjacency()
             self._assign_spice_node_labels_to_pins()
-            self._populate_circuit(circuit, self.pyspice_circuit)
+            circuit_name = self.core.get_attribute(circuit, "name")
+            pyspice_circuit = Circuit(circuit_name)
+            self._populate_circuit(circuit, pyspice_circuit)
+        return pyspice_circuit
 
     def _assign_meta_functions(self) -> None:
         """Assign is_* function for easier meta type checks"""
@@ -82,8 +86,6 @@ class CircuitToPySpiceBase(PluginBase):
         self._ground_pins = set()
         self.nodes_count = 0
         self.pin_labels = dict()
-        circuit_name = self.core.get_attribute(circuit, "name")
-        self.pyspice_circuit = Circuit(circuit_name)
         self._log_debug(f"Initialized empty PySpice circuit for {circuit_name}")
 
     def _identify_pins(self, circuit: dict) -> None:
@@ -535,8 +537,8 @@ class AnalyzeCircuit(CircuitToPySpiceBase):
     """Base class for running various analysis on WebGME node of type Circuit"""
 
     def main(self) -> None:
-        super().convert_to_pyspice(self.active_node)
-        self.run_analytics()
+        circuit = super().convert_to_pyspice(self.active_node)
+        self.run_analytics(circuit)
 
-    def run_analytics(self) -> None:
+    def run_analytics(self, circuit) -> None:
         raise NotImplementedError

--- a/src/common/plugins/CircuitAnalysisBases.py
+++ b/src/common/plugins/CircuitAnalysisBases.py
@@ -86,6 +86,7 @@ class CircuitToPySpiceBase(PluginBase):
         self._ground_pins = set()
         self.nodes_count = 0
         self.pin_labels = dict()
+        circuit_name = self.core.get_attribute(circuit, "name")
         self._log_debug(f"Initialized empty PySpice circuit for {circuit_name}")
 
     def _identify_pins(self, circuit: dict) -> None:

--- a/src/plugins/ConvertCircuitToNetlist/ConvertCircuitToNetlist/__init__.py
+++ b/src/plugins/ConvertCircuitToNetlist/ConvertCircuitToNetlist/__init__.py
@@ -19,9 +19,9 @@ PluginBase = getattr(base_module, BASE_PLUGIN_NAME)
 
 class ConvertCircuitToNetlist(PluginBase):
     def main(self) -> None:
-        super().convert_to_pyspice(self.active_node)
+        circuit = super().convert_to_pyspice(self.active_node)
         output_filename = self.get_current_config().get("file_name")
         if not output_filename:
             output_filename = self.core.get_attribute(self.active_node, "name")
-        self.add_file(f"{output_filename}.cir", str(self.pyspice_circuit))
+        self.add_file(f"{output_filename}.cir", str(circuit))
         self.result_set_success(True)

--- a/src/plugins/RecommendNextComponentsMock/RecommendNextComponentsMock/__init__.py
+++ b/src/plugins/RecommendNextComponentsMock/RecommendNextComponentsMock/__init__.py
@@ -1,6 +1,8 @@
 import json
 from collections import Counter
 from importlib.util import module_from_spec, spec_from_file_location
+from typing import Union
+from PySpice.Spice.Netlist import Circuit, SubCircuit
 from pathlib import Path
 
 BASE_PLUGIN_PATH = Path(
@@ -23,7 +25,7 @@ class RecommendNextComponentsMock(PluginBase):
     def run_analytics(self, circuit) -> None:
         self._recommend_next_components(circuit)
 
-    def _recommend_next_components(self, circuit) -> None:
+    def _recommend_next_components(self, circuit: Union[Circuit, SubCircuit]) -> None:
         component_counts = Counter(
             type(element).__name__ for element in circuit.elements
         )

--- a/src/plugins/RecommendNextComponentsMock/RecommendNextComponentsMock/__init__.py
+++ b/src/plugins/RecommendNextComponentsMock/RecommendNextComponentsMock/__init__.py
@@ -22,7 +22,7 @@ PluginBase = getattr(base_module, BASE_PLUGIN_NAME)
 class RecommendNextComponentsMock(PluginBase):
     """Runs a mock implementation for recommending components to be added to the Circuit"""
 
-    def run_analytics(self, circuit) -> None:
+    def run_analytics(self, circuit: Union[Circuit, SubCircuit]) -> None:
         self._recommend_next_components(circuit)
 
     def _recommend_next_components(self, circuit: Union[Circuit, SubCircuit]) -> None:

--- a/src/plugins/RecommendNextComponentsMock/RecommendNextComponentsMock/__init__.py
+++ b/src/plugins/RecommendNextComponentsMock/RecommendNextComponentsMock/__init__.py
@@ -20,15 +20,15 @@ PluginBase = getattr(base_module, BASE_PLUGIN_NAME)
 class RecommendNextComponentsMock(PluginBase):
     """Runs a mock implementation for recommending components to be added to the Circuit"""
 
-    def run_analytics(self) -> None:
-        self._recommend_next_components()
+    def run_analytics(self, circuit) -> None:
+        self._recommend_next_components(circuit)
 
-    def _recommend_next_components(self) -> None:
+    def _recommend_next_components(self, circuit) -> None:
         component_counts = Counter(
-            type(element).__name__ for element in self.pyspice_circuit.elements
+            type(element).__name__ for element in circuit.elements
         )
 
-        for subckt in self.pyspice_circuit.subcircuits:
+        for subckt in circuit.subcircuits:
             component_counts.update(
                 type(element).__name__ for element in subckt.elements
             )


### PR DESCRIPTION
This moves `self.pyspice_circuit` from a data attribute to be an explicit input/output of the relevant functions.