### PR TITLE
Make Layout for ElectricCircuitsEditor more compact. Closes #116

### DIFF
--- a/src/visualizers/widgets/ElectricCircuitsEditor/CircuitEditorDashboard/src/CircuitEditorDashboard.svelte
+++ b/src/visualizers/widgets/ElectricCircuitsEditor/CircuitEditorDashboard/src/CircuitEditorDashboard.svelte
@@ -80,10 +80,13 @@
     export function zoom(zoomLevel) {
         if (circuitPaper) {
             currentZoomLevel = zoomLevel;
-            circuitPaper.scale(zoomLevel);
+            circuitPaper.scale(zoomLevel * 0.75);
             circuitPaper.fitToContent({
                 useModelGeometry: true,
-                padding: 100 * zoomLevel,
+                padding: {
+                    horizontal: 100 * zoomLevel,
+                    vertical: 30 * zoomLevel
+                },
                 allowNewOrigin: 'any',
                 minWidth: circuitPaper.options.width,
                 minHeight: circuitPaper.options.height

--- a/src/visualizers/widgets/ElectricCircuitsEditor/CircuitEditorDashboard/src/circuits.js
+++ b/src/visualizers/widgets/ElectricCircuitsEditor/CircuitEditorDashboard/src/circuits.js
@@ -20,6 +20,7 @@ const defineElectricCircuitsDomain = function (joint) {
         },
     }, {}, {
         toELKJSON: component => {
+            const labelText = component.get('attrs').text.text;
             return {
                 id: component.id,
                 name: component.get('attrs').text.text,
@@ -29,11 +30,11 @@ const defineElectricCircuitsDomain = function (joint) {
                     portConstraints: 'FIXED_SIDE'
                 },
                 labels: [{
-                    text: component.get('attrs').text.text,
+                    text: labelText,
                     layoutOptions: {
                         'nodeLabels.placement': '[H_CENTER, V_BOTTOM, OUTSIDE]'
                     },
-                    width: 150,
+                    width: labelText ? labelText.length * 10 : 50,
                     height: 20
                 }]
             };
@@ -1004,8 +1005,8 @@ const defineElectricCircuitsDomain = function (joint) {
                 'elk.algorithm': 'layered',
                 'org.eclipse.elk.edgeRouting': 'ORTHOGONAL',
                 'org.eclipse.elk.direction': 'DOWN',
-                'org.eclipse.elk.spacing.nodeNode': 30,
-                'org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers': 30,
+                'org.eclipse.elk.spacing.nodeNode': 15,
+                'org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers': 15,
                 'org.eclipse.elk.layered.spacing.edgeEdgeBetweenLayers': 30,
                 'org.eclipse.elk.spacing.edgeNode': 30,
                 'org.eclipse.elk.spacing.edgeEdge': 30,


### PR DESCRIPTION
1. Decrease NodeNode distance in ELKLayout
2. Default Zoom to 0.75